### PR TITLE
Implement global tasks

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,12 @@ export interface Task {
   createdAt: Date;
   weekId: string; // ISO week format like "2023-W42"
   suggestedBy?: string; // ID of the user who suggested this task (optional)
+  /**
+   * Indicates that the task comes from the user's personal collection rather
+   * than a group. This property is not persisted in Firestore and is derived
+   * from the document path when tasks are loaded.
+   */
+  isGlobal?: boolean;
 }
   
 export interface UserData {


### PR DESCRIPTION
## Summary
- store a `isGlobal` flag on `Task` objects
- merge user-level tasks with group tasks in `TaskTracker`
- update task manipulation functions to work on global tasks

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685be772c75083309b78d4248f0006e4