### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/layout/CompactGroupHeader.tsx
+++ b/src/components/layout/CompactGroupHeader.tsx
@@ -55,13 +55,16 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
           </button>
         </div>
       ) : (
-        <h1 
+        <h1
           className="text-2xl text-gray-800 font-bold cursor-pointer"
           onClick={() => onUpdateName && setIsEditing(true)}
         >
-          {groupName}
+          <span className="sm:hidden">
+            {groupName.length > 8 ? `${groupName.slice(0, 8)}...` : groupName}
+          </span>
+          <span className="hidden sm:inline">{groupName}</span>
         </h1>
       )}
     </div>
   );
-} 
+}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -94,8 +94,10 @@ export default function MainLayout({
   return (
     <div className="flex h-screen relative">
       {/* Left Sidebar - always absolute positioned */}
-      <div className={`absolute top-0 bottom-0 left-0 h-full bg-gray-100 border-r border-gray-200 transition-all duration-300 hidden md:block
-        ${sidebarCollapsed ? 'w-16' : 'w-64 shadow-lg z-10'}`}>
+      <div
+        className={`absolute top-0 bottom-0 left-0 h-full bg-gray-100 border-r border-gray-200 transition-all duration-300
+        ${sidebarCollapsed ? 'w-8 md:w-16' : 'w-full md:w-64 shadow-lg z-10'}`}
+      >
         <div className="h-full flex flex-col">
           <div className={`p-4 text-gray-600 font-bold ${sidebarCollapsed ? 'text-center' : ''}`}>
             {sidebarCollapsed ? '' : 'My Groups'}
@@ -155,7 +157,7 @@ export default function MainLayout({
       </div>
       
       {/* Main Content - fixed margins */}
-      <div className="w-full h-full flex flex-col overflow-hidden md:pl-16 lg:pr-16">
+      <div className="w-full h-full flex flex-col overflow-hidden pl-8 pr-8 md:pl-16 lg:pr-16">
         {/* Clone children with additional props if it's a TaskTracker component */}
         {React.Children.map(children, child => {
           // Check if it's a valid element
@@ -172,8 +174,10 @@ export default function MainLayout({
       </div>
       
       {/* Right Sidebar - always absolute positioned */}
-      <div className={`absolute top-0 bottom-0 right-0 h-full bg-gray-100 border-l border-gray-200 transition-all duration-300 hidden lg:block
-        ${rightSidebarCollapsed ? 'w-16' : 'w-64 shadow-lg z-10'}`}>
+      <div
+        className={`absolute top-0 bottom-0 right-0 h-full bg-gray-100 border-l border-gray-200 transition-all duration-300
+        ${rightSidebarCollapsed ? 'w-8 lg:w-16' : 'w-full lg:w-64 shadow-lg z-10'}`}
+      >
         {groupId && currentWeekId ? (
           <CommentSection 
             groupId={groupId}

--- a/src/components/layout/ShareButton.tsx
+++ b/src/components/layout/ShareButton.tsx
@@ -31,12 +31,12 @@ export default function ShareButton({ groupId }: ShareButtonProps) {
   };
 
   return (
-    <button 
-      onClick={handleShare} 
+    <button
+      onClick={handleShare}
       className="px-3 py-1 text-sm rounded-md bg-blue-100 hover:bg-blue-200 text-blue-700 flex items-center"
     >
-      <ShareIcon className="h-5 w-5 mr-1" />
-      <span className="text-sm">{copied ? "Copied!" : "Share"}</span>
+      <ShareIcon className="h-5 w-5 mr-0 sm:mr-1" />
+      <span className="text-sm hidden sm:inline">{copied ? "Copied!" : "Share"}</span>
     </button>
   );
-} 
+}

--- a/src/components/layout/StatsButton.tsx
+++ b/src/components/layout/StatsButton.tsx
@@ -16,23 +16,17 @@ export default function StatButton({
       onClick={onStatView}
       className="px-3 py-1 rounded-md bg-blue-100 hover:bg-blue-200 text-blue-700 flex items-center"
     >
-      
-      
         {isStatView ? (
           <>
-            <CalendarDaysIcon className="h-5 w-5 mr-1" />
-            <span className="text-sm">
-              Calendar
-            </span>
+            <CalendarDaysIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Calendar</span>
           </>
         ) : (
           <>
-            <ChartBarIcon className="h-5 w-5 mr-1" />
-            <span className="text-sm">
-                Stats
-            </span>
+            <ChartBarIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Stats</span>
           </>
-        )} 
+        )}
     </button>
   );
 }

--- a/src/components/stats/StatsView.tsx
+++ b/src/components/stats/StatsView.tsx
@@ -327,73 +327,90 @@ export default function StatsView({
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-4 relative">
-        <div className="flex justify-between items-center mb-3 relative">
-            {/* Left section: Group name */}
-            <div className="py-2 flex justify-center items-center">
-                <h1 
-                className="text-2xl text-gray-800 font-bold"
-                >{groupName}</h1>
-            </div>
-            {/* Right section: Share button */}
-            <div className="flex gap-4">
-                <div>
-                <StatButton isStatView={isStatView} onStatView={onStatView} />
-                </div>
-                <div>
-                <ShareButton groupId={groupID} />
-                </div>
-            </div>
+      <div className="flex justify-between items-center mb-3 relative">
+        {/* Left section: Group name */}
+        <div className="py-2 flex justify-center items-center">
+          <h1 className="text-2xl text-gray-800 font-bold">{groupName}</h1>
+        </div>
+        {/* Right section: Share button */}
+        <div className="flex gap-4">
+          <div>
+            <StatButton isStatView={isStatView} onStatView={onStatView} />
+          </div>
+          <div>
+            <ShareButton groupId={groupID} />
+          </div>
+        </div>
+      </div>
 
+      {/* Charts */}
+      <div className="grid flex-1 grid-rows-3 md:grid-rows-2 md:grid-cols-2">
+        <div className="row-span-1 md:col-span-2 bg-gray-100 m-2 p-4 rounded-2xl">
+          <Line options={lineOptions} data={lineData} />
         </div>
-        <div className="flex-1 bg-gray-100 m-2 p-4 rounded-2xl">
-          <Line options={lineOptions} data={lineData}/>
+        <div className="bg-gray-100 m-2 p-4 rounded-2xl">
+          <Bar options={barOptions} data={barData} />
         </div>
-        <div className="flex flex-1">
-          <div className='flex-2 bg-gray-100 m-2 p-4 rounded-2xl'>
-            {/*Bar chart*/}
-            <Bar options={barOptions} data={barData}/>
-          </div>
-          <div className='flex flex-1 flex-col justify-start bg-gray-100 m-2 p-4 rounded-2xl'>
-            {/* Leaderboard */}
-            <div className='self-center text-xl text-gray-800 font-bold mb-2  '>
-              Leaderboard
-            </div>
-            <div>
-              <table className='w-full text-gray-800 border-separate border-spacing-x-0 border-spacing-y-1'>
-                <thead>
-                  <tr className=''>
-                    <th className='rounded-l-md bg-gray-300 p-0.5'>Rank</th>
-                    <th className='bg-gray-300'>Name</th>
-                    <th className='rounded-r-md bg-gray-300'>Score</th>
+        <div className="bg-gray-100 m-2 p-4 rounded-2xl overflow-auto flex flex-col">
+          <div className="self-center text-xl text-gray-800 font-bold mb-2">Leaderboard</div>
+          <div>
+            <table className="w-full text-gray-800 border-separate border-spacing-x-0 border-spacing-y-1">
+              <thead>
+                <tr>
+                  <th className="rounded-l-md bg-gray-300 p-0.5">Rank</th>
+                  <th className="bg-gray-300">Name</th>
+                  <th className="rounded-r-md bg-gray-300">Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedMembers.map((member, index) => (
+                  <tr key={member.id}>
+                    <td
+                      className={`text-center rounded-l-md ${
+                        index === 0
+                          ? 'bg-amber-300/80'
+                          : index === 1
+                          ? 'bg-zinc-400/80'
+                          : index === 2
+                          ? 'bg-yellow-600/80'
+                          : 'bg-blue-200'
+                      }`}
+                    >
+                      {index + 1}
+                    </td>
+                    <td
+                      className={`text-center ${
+                        index === 0
+                          ? 'bg-amber-300/80'
+                          : index === 1
+                          ? 'bg-zinc-400/80'
+                          : index === 2
+                          ? 'bg-yellow-600/80'
+                          : 'bg-blue-200'
+                      }`}
+                    >
+                      {member.name}
+                    </td>
+                    <td
+                      className={`text-center rounded-r-md ${
+                        index === 0
+                          ? 'bg-amber-300/80'
+                          : index === 1
+                          ? 'bg-zinc-400/80'
+                          : index === 2
+                          ? 'bg-yellow-600/80'
+                          : 'bg-blue-200'
+                      }`}
+                    >
+                      {(yearlyStats.rates[member.id] * 100 || 0).toFixed(2)}%
+                    </td>
                   </tr>
-                </thead>
-                <tbody>
-                  {sortedMembers.map((member, index) => (
-                    <tr key={member.id} className=''>
-                      <td className={`text-center rounded-l-md ${
-                        index === 0 ? ('bg-amber-300/80') :
-                        index === 1 ? ('bg-zinc-400/80') :
-                        index === 2 ? ('bg-yellow-600/80') :
-                        ('bg-blue-200')}`}>{index + 1}</td>
-                      <td className={`text-center ${
-                        index === 0 ? ('bg-amber-300/80') :
-                        index === 1 ? ('bg-zinc-400/80') :
-                        index === 2 ? ('bg-yellow-600/80') :
-                        ('bg-blue-200')}`}>{member.name}</td>
-                      <td className={`text-center rounded-r-md ${
-                        index === 0 ? ('bg-amber-300/80') :
-                        index === 1 ? ('bg-zinc-400/80') :
-                        index === 2 ? ('bg-yellow-600/80') :
-                        ('bg-blue-200')}`}>
-                        {(yearlyStats.rates[member.id] * 100 || 0).toFixed(2)}%
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
+      </div>
     </div>
   );
 }

--- a/src/components/stats/StatsView.tsx
+++ b/src/components/stats/StatsView.tsx
@@ -326,7 +326,7 @@ export default function StatsView({
   });
 
   return (
-    <div className="flex flex-col h-full overflow-hidden p-4 relative">
+    <div className="flex flex-col h-screen overflow-y-auto p-4 relative">
       <div className="flex justify-between items-center mb-3 relative">
         {/* Left section: Group name */}
         <div className="py-2 flex justify-center items-center">

--- a/src/components/tracker/TaskCell.tsx
+++ b/src/components/tracker/TaskCell.tsx
@@ -178,13 +178,11 @@ export default function TaskCell({
     return (
       <td
         ref={cellRef}
-        className="border p-1 align-top bg-gray-50 border-gray-300 h-full"
+        className="border p-1 align-top bg-gray-50 border-gray-300 h-full min-w-screen sm:min-w-[150px]"
         style={{
           minHeight: '150px',
           position: 'relative',
-          width: '14.28%',
-          maxWidth: '1fr',
-          overflow: 'hidden' // Keep overflow hidden for cell content
+          overflow: 'hidden'
         }}
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => {

--- a/src/components/tracker/TaskTracker.tsx
+++ b/src/components/tracker/TaskTracker.tsx
@@ -488,12 +488,15 @@ export default function TaskTracker({
       </div>
 
       <div className="flex-grow overflow-auto">
-        <table className="w-full border-collapse table-fixed">
+        <table className="border-collapse min-w-max md:w-full">
           <thead>
             <tr>
               <th className="border p-1 bg-gray-50 text-gray-800 w-24">Person</th>
               {dayNames.map((day, index) => (
-                <th key={index} className="border p-1 bg-gray-50 text-gray-800" style={{ width: '14.28%', minWidth: '150px', maxWidth: '1fr' }}>
+                <th
+                  key={index}
+                  className="border p-1 bg-gray-50 text-gray-800 min-w-screen sm:min-w-[150px]"
+                >
                   {day}
                 </th>
               ))}

--- a/src/components/tracker/WeeklyNavigation.tsx
+++ b/src/components/tracker/WeeklyNavigation.tsx
@@ -57,9 +57,9 @@ export default function WeeklyNavigation({
       >
         ←
       </button>
-      
-      <div 
-        className="flex flex-col hover:bg-gray-200 rounded-md items-center w-[265px] cursor-pointer"
+
+      <div
+        className="hidden sm:flex flex-col hover:bg-gray-200 rounded-md items-center w-[265px] cursor-pointer"
         onClick={toggleMonthlyPopup}
       >
         <span className="text-lg font-bold text-gray-800">
@@ -69,7 +69,7 @@ export default function WeeklyNavigation({
           {year}
         </span>
       </div>
-      
+
       <button
         onClick={onNextWeek}
         className="px-2 py-1 bg-gray-200 hover:bg-gray-300 rounded-md text-gray-700 text-sm ml-2"
@@ -81,11 +81,11 @@ export default function WeeklyNavigation({
       {/* Monthly Navigation Popup */}
       {showMonthlyPopup && onMonthSelect && (
         <div
-          className="absolute z-10 top-full mt-2 left-1/2 transform -translate-x-1/2"
+          className="hidden sm:block absolute z-10 top-full mt-2 left-1/2 transform -translate-x-1/2"
           ref={popupRef}
         >
           <div className="relative z-20 bg-white p-4 rounded-lg shadow-xl border border-gray-200 w-auto">
-            <MonthlyNavigation 
+            <MonthlyNavigation
               currentISOWeek={currentISOWeek}
               onMonthSelect={(year, month) => {
                 if (onMonthSelect) {


### PR DESCRIPTION
## Summary
- hide labels on Stats and Share buttons on mobile screens
- truncate group name to eight characters on mobile
- simplify WeeklyNavigation on small devices
- adjust TaskTracker table to allow horizontal scrolling per day

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685c038b33b483309a52dde55a2391b7