### PR TITLE
Refactor group membership model

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,29 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isGroupMember(groupId) {
+      return request.auth.uid in get(/databases/$(database)/documents/groups/$(groupId)).data.memberUids;
+    }
+
+    match /users/{userId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth.uid == userId;
+    }
+
+    match /groups/{groupId} {
+      allow read, delete: if isGroupMember(groupId);
+
+      allow create: if request.auth != null &&
+                     request.auth.uid in request.resource.data.memberUids;
+
+      allow update: if isGroupMember(groupId) || (
+        request.auth.uid in request.resource.data.memberUids &&
+        !(request.auth.uid in resource.data.memberUids) &&
+        resource.data.memberUids.keys().toSet().subsetOf(request.resource.data.memberUids.keys().toSet()) &&
+        request.resource.data.memberUids.size() == resource.data.memberUids.size() + 1
+      );
+    }
+  }
+}

--- a/src/app/invite/[code]/page.tsx
+++ b/src/app/invite/[code]/page.tsx
@@ -46,7 +46,8 @@ export default function InvitePage() {
         
         // Check if user is already in the group
         const groupData = groupSnap.data();
-        const isAlreadyMember = groupData.members.some((member: any) => member.id === user.uid);
+        const memberUids: Record<string, boolean> = groupData.memberUids || {};
+        const isAlreadyMember = !!memberUids[user.uid];
         
         if (isAlreadyMember) {
           router.push('/dashboard');

--- a/src/app/invite/[code]/page.tsx
+++ b/src/app/invite/[code]/page.tsx
@@ -53,20 +53,13 @@ export default function InvitePage() {
           return;
         }
         
-        // Get user's display name and color from completed profile
+        // Ensure the user's profile document exists
         const userRef = doc(db, 'users', user.uid);
-        const userSnap = await getDoc(userRef);
-        const userData = userSnap.data();
-        const displayName = userData?.displayName || 'User';
-        const userColor = userData?.color || '#' + Math.floor(Math.random()*16777215).toString(16);
+        await getDoc(userRef); // ensure user document exists
         
-        // Add user to group members
+        // Add user to group's member map
         await updateDoc(groupRef, {
-          members: arrayUnion({
-            id: user.uid,
-            name: displayName,
-            color: userColor
-          })
+          [`memberUids.${user.uid}`]: true
         });
         
         // Add group to user's groups

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,11 +27,15 @@ export interface UserData {
 export interface GroupData {
   id: string;
   name: string;
-  members: string[];
+  /**
+   * Map of user ids belonging to the group. The value is always `true` and
+   * exists purely to allow efficient membership checks in Firestore security
+   * rules.
+   */
+  memberUids: Record<string, boolean>;
   tasks: Record<string, Task[]>; // userId -> tasks
   createdAt: Date;
   createdBy: string;
-  // Remove weekOffset as it's no longer needed
 }
 
 export interface Comment {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,8 @@ export interface UserData {
   photoURL: string | null;
   groups: string[];
   createdAt: Date;
+  color: string | null;
+  profileCompleted: boolean | null;
 }
 
 export interface GroupData {


### PR DESCRIPTION
## Summary
- model `GroupData` to store `memberUids` map
- fetch members' display names and colors from `users` when loading groups
- create groups with `memberUids` instead of member array
- join groups by updating `memberUids`
- add Firestore security rules for new structure

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6882441fc2a883309a1bc26aa378a0db