### PR TITLE
refactor top bar layout

### DIFF
--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -249,7 +249,7 @@ export default function CommentSection({
               <button
                 onClick={handleAddComment}
                 disabled={!newComment.trim()}
-                className="px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                className="px-2 py-1 bg-theme text-white rounded hover:bg-theme-hover disabled:opacity-50 disabled:cursor-not-allowed text-sm"
               >
                 <PaperAirplaneIcon className="h-5 w-5" />
               </button>

--- a/src/components/layout/CompactGroupHeader.tsx
+++ b/src/components/layout/CompactGroupHeader.tsx
@@ -36,6 +36,7 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
             onChange={(e) => setName(e.target.value)}
             onKeyPress={handleKeyPress}
             className="border text-gray-800 rounded px-2 py-1 text-xl font-bold"
+            maxLength={24}
             autoFocus
           />
           <button
@@ -62,7 +63,7 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
           <span className="sm:hidden">
             {groupName.length > 8 ? `${groupName.slice(0, 12)}...` : groupName}
           </span>
-          <span className="hidden sm:inline">{groupName}</span>
+          <span className="hidden sm:inline">{groupName.length > 25 ? `${groupName.slice(0, 25)}...` : groupName}</span>
         </h1>
       )}
     </div>

--- a/src/components/layout/CompactGroupHeader.tsx
+++ b/src/components/layout/CompactGroupHeader.tsx
@@ -40,7 +40,7 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
           />
           <button
             onClick={handleSave}
-            className="ml-2 bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded"
+            className="ml-2 bg-black text-white px-3 py-1 rounded"
           >
             Save
           </button>
@@ -60,7 +60,7 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
           onClick={() => onUpdateName && setIsEditing(true)}
         >
           <span className="sm:hidden">
-            {groupName.length > 8 ? `${groupName.slice(0, 8)}...` : groupName}
+            {groupName.length > 8 ? `${groupName.slice(0, 12)}...` : groupName}
           </span>
           <span className="hidden sm:inline">{groupName}</span>
         </h1>

--- a/src/components/layout/CompactGroupHeader.tsx
+++ b/src/components/layout/CompactGroupHeader.tsx
@@ -40,18 +40,18 @@ export default function CompactGroupHeader({ groupName, onUpdateName }: CompactG
           />
           <button
             onClick={handleSave}
-            className="ml-2 bg-black text-white px-3 py-1 rounded"
+            className="ml-2 px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
           >
-            Save
+            ✓
           </button>
           <button
             onClick={() => {
               setName(groupName);
               setIsEditing(false);
             }}
-            className="ml-2 bg-red-500 hover:bg-red-600 px-3 py-1 rounded"
+            className="ml-1 px-3 py-2 rounded-full bg-red-500 hover:bg-red-600 text-white flex items-center"
           >
-            Cancel
+            x
           </button>
         </div>
       ) : (

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -140,7 +140,7 @@ export default function MainLayout({
             </div>
           </div>
           
-          <div className="p-4 border-t border-gray-200 flex items-center justify-between">
+          <div className={`p-4 flex items-center justify-between ${sidebarCollapsed ? 'hidden' : 'border-t border-gray-200'}`}>
             <button 
             onClick={handleLogout} 
             className={`inline-flex items-center px-5 text-sm rounded-full bg-theme hover:bg-theme-hover text-white cursor-pointer ${sidebarCollapsed ? 'sr-only' : 'block'}`}
@@ -149,13 +149,6 @@ export default function MainLayout({
             <span className="text-sm">Logout</span>
           </button>
             
-            <button onClick={toggleSidebar} className="text-gray-600 hover:text-gray-900">
-              {sidebarCollapsed ? (
-                <ChevronRightIcon className="h-5 w-5" />
-              ) : (
-                <ChevronLeftIcon className="h-5 w-5" />
-              )}
-            </button>
           </div>
         </div>
       </div>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,18 +1,21 @@
-import React from 'react';
-import CompactGroupHeader from './CompactGroupHeader';
-import ShareButton from './ShareButton';
-import StatButton from './StatsButton';
-import { UserCircleIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import React from 'react'
+import CompactGroupHeader from './CompactGroupHeader'
+import ShareButton from './ShareButton'
+import StatButton from './StatsButton'
+import {
+  UserCircleIcon,
+  ChatBubbleLeftRightIcon,
+} from '@heroicons/react/24/outline'
 
 interface TopBarProps {
-  groupId: string;
-  groupName: string;
-  onUpdateGroupName?: (newName: string) => void;
-  isStatView: boolean;
-  onStatView: () => void;
-  onToggleLeftSidebar?: () => void;
-  onToggleRightSidebar?: () => void;
-  centerContent?: React.ReactNode;
+  groupId: string
+  groupName: string
+  onUpdateGroupName?: (newName: string) => void
+  isStatView: boolean
+  onStatView: () => void
+  onToggleLeftSidebar?: () => void
+  onToggleRightSidebar?: () => void
+  centerContent?: React.ReactNode
 }
 
 export default function TopBar({
@@ -26,40 +29,77 @@ export default function TopBar({
   centerContent,
 }: TopBarProps) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 relative">
-      <div className="flex flex-col items-center sm:flex-row sm:items-center w-full sm:w-auto relative">
-        <div className="flex-shrink-0">
-          <CompactGroupHeader groupName={groupName} onUpdateName={onUpdateGroupName} />
+    <div className="mb-3 relative w-full">
+      {/* mobile: single-row + buttons below */}
+      <div className="lg:hidden">
+        <div className="flex items-center justify-between w-full">
+          <CompactGroupHeader
+            groupName={groupName}
+            onUpdateName={onUpdateGroupName}
+          />
+          {centerContent && (
+            <div className="flex-shrink-0">
+              {centerContent}
+            </div>
+          )}
         </div>
+        <div className="flex justify-center gap-2 items-center mt-2">
+          <button
+            onClick={onToggleLeftSidebar}
+            className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+          >
+            <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Groups</span>
+          </button>
+          <StatButton isStatView={isStatView} onStatView={onStatView} />
+          <ShareButton groupId={groupId} />
+          <button
+            onClick={onToggleRightSidebar}
+            className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+          >
+            <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Comments</span>
+          </button>
+        </div>
+      </div>
+
+      {/* desktop: auto | 1fr | auto */}
+      <div className="hidden lg:grid lg:grid-cols-[auto_1fr_auto] lg:items-center lg:gap-x-4 w-full">
+        {/* left */}
+        <div>
+          <CompactGroupHeader
+            groupName={groupName}
+            onUpdateName={onUpdateGroupName}
+          />
+        </div>
+
+        {/* center */}
         {centerContent && (
-          <div className="mt-2 sm:mt-0 w-full flex justify-center sm:absolute sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:pointer-events-none">
-            <div className="pointer-events-auto relative">{centerContent}</div>
+          <div className="justify-self-center">
+            {centerContent}
           </div>
         )}
-      </div>
-      <div className="flex gap-2 items-center justify-end mt-2 sm:mt-0">
-        <button
-          onClick={onToggleLeftSidebar}
-          className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-        >
-          <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
-          <span className="text-sm hidden sm:inline">Groups</span>
-        </button>
-        <div>
+
+        {/* right */}
+        <div className="justify-self-end flex gap-2 items-center">
+          <button
+            onClick={onToggleLeftSidebar}
+            className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+          >
+            <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Groups</span>
+          </button>
           <StatButton isStatView={isStatView} onStatView={onStatView} />
-        </div>
-        <div>
           <ShareButton groupId={groupId} />
+          <button
+            onClick={onToggleRightSidebar}
+            className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+          >
+            <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
+            <span className="text-sm hidden sm:inline">Comments</span>
+          </button>
         </div>
-        <button
-          onClick={onToggleRightSidebar}
-          className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-        >
-          <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
-          <span className="text-sm hidden sm:inline">Comments</span>
-        </button>
       </div>
     </div>
-  );
+  )
 }
-

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import CompactGroupHeader from './CompactGroupHeader';
+import ShareButton from './ShareButton';
+import StatButton from './StatsButton';
+import { UserCircleIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+
+interface TopBarProps {
+  groupId: string;
+  groupName: string;
+  onUpdateGroupName?: (newName: string) => void;
+  isStatView: boolean;
+  onStatView: () => void;
+  onToggleLeftSidebar?: () => void;
+  onToggleRightSidebar?: () => void;
+  centerContent?: React.ReactNode;
+}
+
+export default function TopBar({
+  groupId,
+  groupName,
+  onUpdateGroupName,
+  isStatView,
+  onStatView,
+  onToggleLeftSidebar,
+  onToggleRightSidebar,
+  centerContent,
+}: TopBarProps) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 relative">
+      <div className="flex flex-col items-center sm:flex-row sm:items-center w-full sm:w-auto relative">
+        <div className="flex-shrink-0">
+          <CompactGroupHeader groupName={groupName} onUpdateName={onUpdateGroupName} />
+        </div>
+        {centerContent && (
+          <div className="mt-2 sm:mt-0 w-full flex justify-center sm:absolute sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:pointer-events-none">
+            <div className="pointer-events-auto relative">{centerContent}</div>
+          </div>
+        )}
+      </div>
+      <div className="flex gap-2 items-center justify-end mt-2 sm:mt-0">
+        <button
+          onClick={onToggleLeftSidebar}
+          className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
+        >
+          <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
+          <span className="text-sm hidden sm:inline">Groups</span>
+        </button>
+        <div>
+          <StatButton isStatView={isStatView} onStatView={onStatView} />
+        </div>
+        <div>
+          <ShareButton groupId={groupId} />
+        </div>
+        <button
+          onClick={onToggleRightSidebar}
+          className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
+        >
+          <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
+          <span className="text-sm hidden sm:inline">Comments</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/stats/StatsView.tsx
+++ b/src/components/stats/StatsView.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import StatButton from '../layout/StatsButton';
-import ShareButton from '../layout/ShareButton';
-import { UserCircleIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import TopBar from '../layout/TopBar';
 import { 
   Chart as ChartJS, 
   CategoryScale, 
@@ -336,35 +334,14 @@ export default function StatsView({
 
   return (
     <div className="flex flex-col h-screen overflow-y-auto p-4 relative">
-      <div className="flex justify-between items-center mb-3 relative">
-        {/* Left section: Group name */}
-        <div className="py-2 flex justify-center items-center">
-          <h1 className="text-2xl text-gray-800 font-bold">{groupName}</h1>
-        </div>
-        {/* Right section: buttons */}
-        <div className="flex gap-2 items-center">
-            <button
-              onClick={onToggleLeftSidebar}
-              className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-            >
-              <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
-              <span className="text-sm hidden sm:inline">Groups</span>
-            </button>
-          <div>
-            <StatButton isStatView={isStatView} onStatView={onStatView} />
-          </div>
-          <div>
-            <ShareButton groupId={groupID} />
-          </div>
-            <button
-              onClick={onToggleRightSidebar}
-              className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-            >
-              <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
-              <span className="text-sm hidden sm:inline">Comments</span>
-              </button>
-        </div>
-      </div>
+      <TopBar
+        groupId={groupID}
+        groupName={groupName}
+        isStatView={isStatView}
+        onStatView={onStatView}
+        onToggleLeftSidebar={onToggleLeftSidebar}
+        onToggleRightSidebar={onToggleRightSidebar}
+      />
 
       {/* Charts */}
       <div className="grid flex-1 grid-rows-3 md:grid-rows-2 md:grid-cols-2">

--- a/src/components/tracker/TaskTracker.tsx
+++ b/src/components/tracker/TaskTracker.tsx
@@ -3,14 +3,11 @@ import { useAuth } from '../../lib/hooks/useAuth';
 import { Task, Comment } from '../../types';
 import TaskCell from './TaskCell';
 import WeeklyNavigation from './WeeklyNavigation';
-import CompactGroupHeader from '../layout/CompactGroupHeader';
-import ShareButton from '../layout/ShareButton';
+import TopBar from '../layout/TopBar';
 import { collection, addDoc, updateDoc, doc, query, where, onSnapshot, deleteDoc } from 'firebase/firestore';
 import { db } from '../../lib/firebase';
 import { getCurrentISOWeek, getRelativeISOWeek, getDateFromISOWeek, getMonthFirstWeek, getISOWeek } from '../../lib/dateUtils';
 import ThisWeekButton from './ThisWeekButton';
-import StatButton from '../layout/StatsButton';
-import { UserCircleIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 
 // Helper function to get day names with dates for a specific ISO week
 const getDayNames = (isoWeek: string) => {
@@ -458,26 +455,22 @@ export default function TaskTracker({
 
   return (
     <div className="flex flex-col h-full overflow-hidden p-4 relative">
-      <div className="flex justify-between items-center mb-3 relative">
-        {/* Left section: Group name */}
-        <div className="flex-shrink-0">
-          <CompactGroupHeader
-            groupName={currentGroupName}
-            onUpdateName={handleUpdateGroupName}
-          />
-        </div>
-        
-        {/* Middle section: Weekly navigation - absolutely positioned */}
-        <div className="absolute left-0 right-0 flex justify-center pointer-events-none">
-          <div className="pointer-events-auto relative">
-            {/* Position ThisWeekButton absolutely relative to the centered WeeklyNavigation */}
+      <TopBar
+        groupId={groupId}
+        groupName={currentGroupName}
+        onUpdateGroupName={handleUpdateGroupName}
+        isStatView={isStatView}
+        onStatView={onStatView}
+        onToggleLeftSidebar={onToggleLeftSidebar}
+        onToggleRightSidebar={onToggleRightSidebar}
+        centerContent={
+          <div className="relative">
             <div className="absolute right-full w-[120px] top-1/2 -translate-y-1/2">
               <ThisWeekButton
                 currentISOWeek={currentISOWeek}
                 onCurrentWeek={handleCurrentWeek}
               />
             </div>
-            
             <WeeklyNavigation
               currentISOWeek={currentISOWeek}
               onPreviousWeek={handlePreviousWeek}
@@ -486,32 +479,8 @@ export default function TaskTracker({
               onYearSelect={handleYearSelect}
             />
           </div>
-        </div>
-        
-        {/* Right section: buttons */}
-        <div className="flex gap-2 items-center">
-            <button
-              onClick={onToggleLeftSidebar}
-              className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-            >
-              <UserCircleIcon className="h-5 w-5 mr-0 sm:mr-1" />
-              <span className="text-sm hidden sm:inline">Groups</span>
-              </button>
-          <div>
-            <StatButton isStatView={isStatView} onStatView={onStatView} />
-          </div>
-          <div>
-            <ShareButton groupId={groupId} />
-          </div>
-            <button
-              onClick={onToggleRightSidebar}
-              className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center cursor-pointer"
-            >
-              <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
-              <span className="text-sm hidden sm:inline">Comments</span>
-            </button>
-        </div>
-      </div>
+        }
+      />
 
       <div className="flex-grow overflow-auto">
         <table className="border-separate border-spacing-x-1 border-spacing-y-2 md:w-full table-fixed">


### PR DESCRIPTION
## Summary
- add reusable `TopBar` component with responsive two-row mobile layout
- integrate `TopBar` into tracker and stats views to eliminate duplicate logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890774828f08330bfb12f10f828d22b