### PR TITLE
Improve mobile task interactions

### DIFF
--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -89,10 +89,13 @@ export default function CommentSection({
   // Add an effect to handle clicks outside of the task cell
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      // If there's a selected task and the click is not within a task element
-      if (selectedTask && 
-          !(e.target as Element)?.closest('[data-task-item="true"]') && 
-          !containerRef.current?.contains(e.target as Node)) {
+      const target = e.target as Element;
+      if (
+        selectedTask &&
+        !target.closest('[data-task-item="true"]') &&
+        !containerRef.current?.contains(target) &&
+        !target.closest('[data-comment-toggle="true"]')
+      ) {
         onSelectTask(null);
       }
     };

--- a/src/components/layout/CompactGroupHeader.tsx
+++ b/src/components/layout/CompactGroupHeader.tsx
@@ -44,7 +44,7 @@ export default function CompactGroupHeader({
           />
           <button
             onClick={handleSave}
-            className="ml-2 h-full px-3 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+            className="w-8 h-8 ml-1 px-3 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
           >
             ✓
           </button>
@@ -53,7 +53,7 @@ export default function CompactGroupHeader({
               setName(groupName);
               setIsEditing(false);
             }}
-            className="ml-1 h-full px-3 rounded-full bg-red-500 hover:bg-red-600 text-white flex items-center"
+            className="w-8 h-8 ml-1 px-3 rounded-full bg-red-500 hover:bg-red-600 text-white flex items-center"
           >
             x
           </button>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -56,6 +56,7 @@ export default function TopBar({
           <button
             onClick={onToggleRightSidebar}
             className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+            data-comment-toggle="true"
           >
             <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
             <span className="text-sm hidden sm:inline">Comments</span>
@@ -94,6 +95,7 @@ export default function TopBar({
           <button
             onClick={onToggleRightSidebar}
             className="px-3 py-2 rounded-full bg-theme hover:bg-theme-hover text-white flex items-center"
+            data-comment-toggle="true"
           >
             <ChatBubbleLeftRightIcon className="h-5 w-5 mr-0 sm:mr-1" />
             <span className="text-sm hidden sm:inline">Comments</span>

--- a/src/components/tracker/TaskItem.tsx
+++ b/src/components/tracker/TaskItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Task } from '../../types';
 import { ArrowRightIcon, TrashIcon } from '@heroicons/react/24/outline';
 
@@ -72,6 +72,19 @@ export default function TaskItem({
     setShowButtons(false);
   };
 
+  const handleClick = () => {
+    onSelect?.();
+    if (isCurrentUser) {
+      setShowButtons(true);
+    }
+  };
+
+  useEffect(() => {
+    if (!isHighlighted) {
+      setShowButtons(false);
+    }
+  }, [isHighlighted]);
+
   const handleEditClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setIsEditing(true);
@@ -100,7 +113,7 @@ export default function TaskItem({
         ${onSelect ? 'cursor-pointer' : ''}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      onClick={onSelect}
+      onClick={handleClick}
       data-task-item="true"
     >
       {/* Comment icon - shows in top right corner when task has comments */}


### PR DESCRIPTION
## Summary
- Show edit/delete controls when tapping a task on mobile
- Preserve task highlight when opening comments sidebar
- Ignore comment toggle button when clearing task selection

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890cd3067948330b8bc60ea60091259