### PR TITLE
Add onboarding tutorial modal

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { getCurrentISOWeek } from '../../lib/dateUtils';
 import { nanoid } from 'nanoid';
 import StatsView from '../../components/stats/StatsView';
 import ConfirmModal from '../../components/modals/ConfirmModal';
+import TutorialModal from '../../components/modals/TutorialModal';
 import { PlusIcon } from '@heroicons/react/24/outline';
 
 interface GroupData {
@@ -35,6 +36,21 @@ export default function DashboardPage() {
   const [currentISOWeek, setCurrentISOWeek] = useState(getCurrentISOWeek());
   const [isStatView, setStatView] = useState(false);
   const [groupToLeave, setGroupToLeave] = useState<string | null>(null);
+  const [showTutorial, setShowTutorial] = useState(false);
+  const tutorialSlides = [
+    {
+      image: '/android-chrome-192x192.png',
+      text: 'Track your tasks and stay organized.',
+    },
+    {
+      image: '/android-chrome-512x512.png',
+      text: 'Invite friends to collaborate in groups.',
+    },
+    {
+      image: '/google-logo.svg',
+      text: 'View statistics to see your progress.',
+    },
+  ];
 
 
   useEffect(() => {
@@ -57,10 +73,14 @@ export default function DashboardPage() {
       } else {
         setNeedsProfileSetup(false);
       }
-      
+
+      const userData = userDoc.data();
+      if (!userData.tutorialSeen) {
+        setShowTutorial(true);
+      }
+
       // Fetch user's groups
       try {
-        const userData = userDoc.data();
         const userGroups = userData.groups || [];
         
         if (userGroups.length === 0) {
@@ -184,7 +204,7 @@ export default function DashboardPage() {
       }
     };
 
-    const handleLeaveGroup = async () => {
+  const handleLeaveGroup = async () => {
         if (!user || !groupToLeave) return;
         const groupId = groupToLeave;
 
@@ -210,11 +230,18 @@ export default function DashboardPage() {
         } finally {
           setGroupToLeave(null);
         }
-      };
+  };
 
-    const promptLeaveGroup = (groupId: string) => {
-        setGroupToLeave(groupId);
-    };
+  const promptLeaveGroup = (groupId: string) => {
+    setGroupToLeave(groupId);
+  };
+
+  const handleFinishTutorial = async () => {
+    setShowTutorial(false);
+    if (user) {
+      await updateDoc(doc(db, 'users', user.uid), { tutorialSeen: true });
+    }
+  };
 
 
 
@@ -277,6 +304,12 @@ export default function DashboardPage() {
 
   return (
     <>
+      {showTutorial && (
+        <TutorialModal
+          slides={tutorialSlides}
+          onFinish={handleFinishTutorial}
+        />
+      )}
       <MainLayout
         groups={groups}
         selectedGroup={selectedGroup}

--- a/src/components/modals/TutorialModal.tsx
+++ b/src/components/modals/TutorialModal.tsx
@@ -65,7 +65,7 @@ export default function TutorialModal({ slides, onFinish }: TutorialModalProps) 
           </button>
           <button
             onClick={handleNext}
-            className="px-4 py-2 text-sm rounded-full bg-blue-500 hover:bg-blue-600 text-white"
+            className="px-4 py-2 text-sm rounded-full bg-theme hover:bg-theme-hover text-white"
           >
             {index === slides.length - 1 ? 'Finish' : 'Next'}
           </button>

--- a/src/components/modals/TutorialModal.tsx
+++ b/src/components/modals/TutorialModal.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+
+interface Slide {
+  image: string;
+  text: string;
+}
+
+interface TutorialModalProps {
+  slides: Slide[];
+  onFinish: () => void;
+}
+
+export default function TutorialModal({ slides, onFinish }: TutorialModalProps) {
+  const [index, setIndex] = useState(0);
+
+  const handleNext = () => {
+    if (index === slides.length - 1) {
+      onFinish();
+    } else {
+      setIndex(index + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    if (index > 0) {
+      setIndex(index - 1);
+    }
+  };
+
+  const current = slides[index];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="w-full h-48 mb-4 relative">
+          <Image
+            src={current.image}
+            alt="Tutorial step"
+            fill
+            className="object-contain"
+          />
+        </div>
+        <div className="flex justify-center mb-4">
+          {slides.map((_, i) => (
+            <span
+              key={i}
+              className={`h-2 w-2 rounded-full mx-1 ${
+                i === index ? 'bg-blue-500' : 'bg-gray-300'
+              }`}
+            />
+          ))}
+        </div>
+        <p className="text-sm text-gray-700 mb-6">{current.text}</p>
+        <div className="flex justify-between">
+          <button
+            onClick={handlePrev}
+            disabled={index === 0}
+            className="px-4 py-2 text-sm rounded-full bg-gray-200 hover:bg-gray-300 text-gray-700 disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <button
+            onClick={handleNext}
+            className="px-4 py-2 text-sm rounded-full bg-blue-500 hover:bg-blue-600 text-white"
+          >
+            {index === slides.length - 1 ? 'Finish' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce a reusable `TutorialModal` with image slides, navigation dots, and prev/next/finish controls
- show tutorial on first dashboard visit until user completes it

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: failed to fetch fonts)


------
https://chatgpt.com/codex/tasks/task_e_689325f8a4bc8330b4bae1aa9d8586e8