### PR TITLE
Fix comment color updates after user color change

### DIFF
--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -6,9 +6,11 @@ interface CommentItemProps {
   onHover: () => void;
   onLeave: () => void;
   isHighlighted: boolean;
+  /** Color assigned to the comment's author */
+  color: string;
 }
 
-export default function CommentItem({ comment, onHover, onLeave, isHighlighted }: CommentItemProps) {
+export default function CommentItem({ comment, onHover, onLeave, isHighlighted, color }: CommentItemProps) {
   const formatDateTime = (date: Date) => {
     // Format with date and 24-hour time
     return `${date.toLocaleDateString()} ${date.getHours()}:${date.getMinutes().toString().padStart(2, '0')}`;
@@ -28,10 +30,10 @@ export default function CommentItem({ comment, onHover, onLeave, isHighlighted }
   };
 
   return (
-    <div 
+    <div
       className={`p-3 rounded-lg mb-3 border-l-4 shadow-sm bg-white
         ${isHighlighted && comment.taskId ? 'ring-2 ring-blue-400' : ''}`}
-      style={{ borderLeftColor: comment.userColor }}
+      style={{ borderLeftColor: color }}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >

--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -180,40 +180,53 @@ export default function CommentSection({
         {/* Comment list */}
         {isCollapsed ? (
           <div className="px-2 py-4">
-            {comments.slice(0, 5).map(comment => (
-              <div 
-                key={comment.id}
-                className="h-8 w-8 rounded-full mb-2 flex items-center justify-center text-white font-medium"
-                style={{ backgroundColor: comment.userColor }}
-                title={`${comment.userName}: ${comment.text}`}
-              >
-                {comment.userName.charAt(0)}
-              </div>
-            ))}
+            {comments.slice(0, 5).map(comment => {
+              const memberColor =
+                members.find(m => m.id === comment.userId)?.color ||
+                comment.userColor ||
+                '#3B82F6';
+              return (
+                <div
+                  key={comment.id}
+                  className="h-8 w-8 rounded-full mb-2 flex items-center justify-center text-white font-medium"
+                  style={{ backgroundColor: memberColor }}
+                  title={`${comment.userName}: ${comment.text}`}
+                >
+                  {comment.userName.charAt(0)}
+                </div>
+              );
+            })}
           </div>
-        )  : (
+        ) : (
           <div className="p-4">
-            {filteredComments.map(comment => (
-              <CommentItem 
-                key={comment.id}
-                comment={comment}
-                isHighlighted={!!(comment.id === highlightedCommentId || 
-                  (comment.taskId && comment.taskId === highlightedTaskId))}
-                onHover={() => {
-                  setHighlightedCommentId(comment.id);
-                  if (comment.taskId) {
-                    onHighlightTask(comment.taskId);
-                  }
-                }}
-                onLeave={() => {
-                  setHighlightedCommentId(null);
-                  onHighlightTask(null);
-                }}
-              />
-            ))}
+            {filteredComments.map(comment => {
+              const memberColor =
+                members.find(m => m.id === comment.userId)?.color ||
+                comment.userColor ||
+                '#3B82F6';
+              return (
+                <CommentItem
+                  key={comment.id}
+                  comment={comment}
+                  color={memberColor}
+                  isHighlighted={!!(comment.id === highlightedCommentId ||
+                    (comment.taskId && comment.taskId === highlightedTaskId))}
+                  onHover={() => {
+                    setHighlightedCommentId(comment.id);
+                    if (comment.taskId) {
+                      onHighlightTask(comment.taskId);
+                    }
+                  }}
+                  onLeave={() => {
+                    setHighlightedCommentId(null);
+                    onHighlightTask(null);
+                  }}
+                />
+              );
+            })}
             {filteredComments.length === 0 && (
               <div className="text-gray-500 text-center italic">
-                {selectedTask ? "No comments for this task yet" : "No comments yet"}
+                {selectedTask ? 'No comments for this task yet' : 'No comments yet'}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- pass member color into CommentItem so old comments reflect updated user colors
- look up each comment's color from current group membership when rendering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987e30dbf48330ada4ae88b8817d4d