### PR TITLE
feat: add toggling tick/cross sign-in background

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { useAuth } from '../../lib/hooks/useAuth';
 import Image from 'next/image';
+import { useAuth } from '../../lib/hooks/useAuth';
+import TickCrossBackground from './TickCrossBackground';
 
 export default function LoginForm() {
   const { signInWithGoogle } = useAuth();
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-8 bg-gray-50">
-      <div className="bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
+    <div className="relative flex flex-col items-center justify-center min-h-screen p-8 bg-gray-50 overflow-hidden">
+      <TickCrossBackground />
+      <div className="relative z-10 bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
       <div className="flex items-center justify-center mb-8">
         <h1 className="text-3xl font-bold text-black">
           cheat-code.

--- a/src/components/auth/TickCrossBackground.tsx
+++ b/src/components/auth/TickCrossBackground.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+const CELL_SIZE = 60; // pixels for each square
+
+export default function TickCrossBackground() {
+  const [rows, setRows] = useState(0);
+  const [cols, setCols] = useState(0);
+  const [states, setStates] = useState<boolean[]>([]);
+
+  const initStates = (r: number, c: number) =>
+    Array.from({ length: r * c }, (_, idx) => {
+      const row = Math.floor(idx / c);
+      const col = idx % c;
+      return (row + col) % 2 === 0; // true => tick, false => cross
+    });
+
+  useEffect(() => {
+    const updateGrid = () => {
+      const c = Math.ceil(window.innerWidth / CELL_SIZE);
+      const r = Math.ceil(window.innerHeight / CELL_SIZE);
+      setRows(r);
+      setCols(c);
+      setStates(initStates(r, c));
+    };
+
+    updateGrid();
+    window.addEventListener('resize', updateGrid);
+    return () => window.removeEventListener('resize', updateGrid);
+  }, []);
+
+  const toggle = (index: number) => {
+    setStates((prev) => {
+      const next = [...prev];
+      next[index] = !next[index];
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="absolute inset-0 grid"
+      style={{
+        gridTemplateColumns: `repeat(${cols}, ${CELL_SIZE}px)`,
+        gridTemplateRows: `repeat(${rows}, ${CELL_SIZE}px)`,
+      }}
+    >
+      {states.map((isTick, idx) => (
+        <button
+          key={idx}
+          onClick={() => toggle(idx)}
+          className="flex items-center justify-center"
+        >
+          <span className="w-8 h-8 rounded-full bg-white/70 flex items-center justify-center">
+            {isTick ? (
+              <CheckIcon className="w-5 h-5 text-green-600" />
+            ) : (
+              <XMarkIcon className="w-5 h-5 text-red-600" />
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TickCrossBackground component that draws an alternating grid of tick and cross icons
- integrate interactive background into login form

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989335b29083309c4c561f4a7a1e33