### PR TITLE
feat: add demo task and announcement boxes

### DIFF
--- a/src/components/auth/AnnouncementsBox.tsx
+++ b/src/components/auth/AnnouncementsBox.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function AnnouncementsBox() {
+  return (
+    <div className="bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
+      <h2 className="text-xl font-bold text-black mb-4">Announcements</h2>
+      <p className="text-black text-sm">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Image from 'next/image';
 import { useAuth } from '../../lib/hooks/useAuth';
 import TickCrossBackground from './TickCrossBackground';
+import TaskDemoBox from './TaskDemoBox';
+import AnnouncementsBox from './AnnouncementsBox';
 
 export default function LoginForm() {
   const { signInWithGoogle } = useAuth();
@@ -9,36 +11,39 @@ export default function LoginForm() {
   return (
     <div className="relative flex flex-col items-center justify-center min-h-screen p-8 bg-gray-50 overflow-hidden">
       <TickCrossBackground />
-      <div className="relative z-10 bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
-      <div className="flex items-center justify-center mb-8">
-        <h1 className="text-3xl font-bold text-black">
-          cheat-code.
-        </h1>
-        <Image
-          src="/android-chrome-192x192.png"
-          alt="cc logo"
-          width={36}
-          height={36}
-          className="h-9 w-9 relative top-0.75"
-        />
-      </div>
-        <p className="mb-8 text-center max-w-md text-black">
-          Stay accountable together.
-        </p>
-        
-        <div className="flex justify-center">
-          <button
-            onClick={signInWithGoogle}
-            className="flex items-center gap-3 bg-white text-gray-700 px-6 py-3 rounded-md shadow hover:shadow-md transition-shadow"
-          >
-            <Image 
-              src="/google-logo.svg" 
-              alt="Google Logo" 
-              width={20} 
-              height={20} 
+      <div className="relative z-10 flex flex-col md:flex-row md:items-start gap-8 overflow-y-auto max-h-screen">
+        <div className="order-2 md:order-1">
+          <TaskDemoBox />
+        </div>
+        <div className="order-1 md:order-2 bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
+          <div className="flex items-center justify-center mb-8">
+            <h1 className="text-3xl font-bold text-black">cheat-code.</h1>
+            <Image
+              src="/android-chrome-192x192.png"
+              alt="cc logo"
+              width={36}
+              height={36}
+              className="h-9 w-9 relative top-0.75"
             />
-            Sign in with Google
-          </button>
+          </div>
+          <p className="mb-8 text-center max-w-md text-black">Stay accountable together.</p>
+          <div className="flex justify-center">
+            <button
+              onClick={signInWithGoogle}
+              className="flex items-center gap-3 bg-white text-gray-700 px-6 py-3 rounded-md shadow hover:shadow-md transition-shadow"
+            >
+              <Image
+                src="/google-logo.svg"
+                alt="Google Logo"
+                width={20}
+                height={20}
+              />
+              Sign in with Google
+            </button>
+          </div>
+        </div>
+        <div className="order-3 md:order-3">
+          <AnnouncementsBox />
         </div>
       </div>
     </div>

--- a/src/components/auth/TaskDemoBox.tsx
+++ b/src/components/auth/TaskDemoBox.tsx
@@ -1,0 +1,173 @@
+import React, { useState } from 'react';
+import { nanoid } from 'nanoid';
+import TaskCell from '../tracker/TaskCell';
+import { Task } from '../../types';
+
+export default function TaskDemoBox() {
+  const today = new Date();
+  const formattedDate = today.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const members = [
+    { id: 'alp', name: 'Alp', color: '#3B82F6' },
+    { id: 'you', name: 'You', color: '#10B981' },
+  ];
+
+  const [tasks, setTasks] = useState<Record<string, Task[]>>({
+    alp: [
+      {
+        id: nanoid(),
+        text: 'Launch cheatcode',
+        status: 'not-done',
+        day: 0,
+        createdBy: 'alp',
+        createdAt: new Date(),
+        weekId: 'demo',
+      },
+      {
+        id: nanoid(),
+        text: 'Birthday',
+        status: 'not-done',
+        day: 0,
+        createdBy: 'alp',
+        createdAt: new Date(),
+        weekId: 'demo',
+      },
+    ],
+    you: [],
+  });
+
+  const handleAddTask = (memberId: string, text: string) => {
+    setTasks(prev => {
+      const memberTasks = prev[memberId] || [];
+      if (memberTasks.length >= 2) return prev;
+      const newTask: Task = {
+        id: nanoid(),
+        text,
+        status: 'not-done',
+        day: 0,
+        createdBy: memberId,
+        createdAt: new Date(),
+        weekId: 'demo',
+        elapsedSeconds: 0,
+        timerStartedAt: null,
+      };
+      return { ...prev, [memberId]: [...memberTasks, newTask] };
+    });
+  };
+
+  const handleUpdateStatus = (memberId: string, taskId: string) => {
+    setTasks(prev => ({
+      ...prev,
+      [memberId]: prev[memberId].map(t =>
+        t.id === taskId
+          ? { ...t, status: t.status === 'completed' ? 'not-done' : 'completed' }
+          : t
+      ),
+    }));
+  };
+
+  const handleDeleteTask = (memberId: string, taskId: string) => {
+    setTasks(prev => ({
+      ...prev,
+      [memberId]: prev[memberId].filter(t => t.id !== taskId),
+    }));
+  };
+
+  const handleEditTask = (memberId: string, taskId: string, newText: string) => {
+    setTasks(prev => ({
+      ...prev,
+      [memberId]: prev[memberId].map(t =>
+        t.id === taskId ? { ...t, text: newText } : t
+      ),
+    }));
+  };
+
+  const handleStartTimer = (memberId: string, taskId: string) => {
+    setTasks(prev => ({
+      ...prev,
+      [memberId]: prev[memberId].map(t =>
+        t.id === taskId ? { ...t, timerStartedAt: new Date() } : t
+      ),
+    }));
+  };
+
+  const handleStopTimer = (memberId: string, taskId: string) => {
+    setTasks(prev => ({
+      ...prev,
+      [memberId]: prev[memberId].map(t => {
+        if (t.id === taskId && t.timerStartedAt) {
+          const start = new Date(t.timerStartedAt).getTime();
+          const now = Date.now();
+          const elapsed = t.elapsedSeconds || 0;
+          return {
+            ...t,
+            elapsedSeconds: elapsed + Math.floor((now - start) / 1000),
+            timerStartedAt: null,
+          };
+        }
+        return t;
+      }),
+    }));
+  };
+
+  const [currentTaskType, setCurrentTaskType] = useState<'local' | 'global'>('local');
+
+  return (
+    <div className="bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
+      <div className="text-center font-bold mb-4 text-black">{formattedDate}</div>
+      <table className="border-separate border-spacing-x-1 border-spacing-y-2 w-full table-fixed">
+        <tbody>
+          {members.map(member => (
+            <tr key={member.id}>
+              <td
+                className="rounded-l-2xl p-1 font-bold text-white text-center relative"
+                style={{
+                  backgroundColor: member.color,
+                  width: '50px',
+                  height: '80px',
+                  boxShadow: '-10px 0 0 0 white',
+                }}
+              >
+                <div
+                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform -rotate-90 break-words"
+                  style={{
+                    width: '80px',
+                    maxHeight: '50px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: '-webkit-box',
+                    WebkitLineClamp: '2',
+                    WebkitBoxOrient: 'vertical',
+                  }}
+                >
+                  {member.name}
+                </div>
+              </td>
+              <TaskCell
+                memberId={member.id}
+                day={0}
+                tasks={tasks[member.id] || []}
+                onAddTask={text => handleAddTask(member.id, text)}
+                onUpdateTaskStatus={taskId => handleUpdateStatus(member.id, taskId)}
+                onDeleteTask={taskId => handleDeleteTask(member.id, taskId)}
+                onEditTask={(taskId, newText) => handleEditTask(member.id, taskId, newText)}
+                onStartTimer={taskId => handleStartTimer(member.id, taskId)}
+                onStopTimer={taskId => handleStopTimer(member.id, taskId)}
+                isCurrentUser={member.id === 'you'}
+                members={members}
+                currentUserId={'you'}
+                currentTaskType={currentTaskType}
+                onTaskTypeChange={setCurrentTaskType}
+                minHeight={100}
+              />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/tracker/TaskCell.tsx
+++ b/src/components/tracker/TaskCell.tsx
@@ -30,6 +30,8 @@ interface TaskCellProps {
   // New props for global task type state
   currentTaskType: TaskType;
   onTaskTypeChange: (type: TaskType) => void;
+  /** Optional minimum height for the cell in pixels */
+  minHeight?: number;
 }
 
 export default function TaskCell({
@@ -55,6 +57,7 @@ export default function TaskCell({
   // Destructure new props
   currentTaskType,
   onTaskTypeChange,
+  minHeight,
 }: TaskCellProps) {
     const [newTaskText, setNewTaskText] = useState('');
     const [isHovering, setIsHovering] = useState(false);
@@ -205,9 +208,10 @@ export default function TaskCell({
     return (
       <td
         ref={cellRef}
-        className="p-1 relative align-top h-full overflow-hidden min-h-[150px]"
+        className="p-1 relative align-top h-full overflow-hidden"
         style={{
-          backgroundColor: `${color}10`
+          backgroundColor: `${color}10`,
+          minHeight: minHeight ?? 150,
         }}
         onMouseEnter={() => setIsHovering(true)}
         onTouchStart={() => setIsHovering(true)} 


### PR DESCRIPTION
## Summary
- show sample task tracker and announcements boxes alongside login
- allow TaskCell to accept a custom minimum height for flexible layouts

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68989dc2fa00833095afb4d5b496330d