### PR TITLE
Enhance invite and dashboard loading visuals

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,7 +13,7 @@ import { nanoid } from 'nanoid';
 import StatsView from '../../components/stats/StatsView';
 import ConfirmModal from '../../components/modals/ConfirmModal';
 import TutorialModal from '../../components/modals/TutorialModal';
-import { PlusIcon } from '@heroicons/react/24/outline';
+import { PlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 interface GroupData {
   id: string;
@@ -324,7 +324,13 @@ export default function DashboardPage() {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-12 h-12 flex items-center justify-center rounded-full bg-red-400 animate-spin">
+          <XMarkIcon className="w-8 h-8 text-white" />
+        </div>
+      </div>
+    );
   }
 
   if (!user) {

--- a/src/app/invite/[code]/page.tsx
+++ b/src/app/invite/[code]/page.tsx
@@ -6,6 +6,7 @@ import { doc, getDoc, updateDoc, arrayUnion } from 'firebase/firestore';
 import { db } from '../../../lib/firebase';
 import { useAuth } from '../../../lib/hooks/useAuth';
 import { useParams } from 'next/navigation';
+import TickCrossBackground from '../../../components/auth/TickCrossBackground';
 
 export default function InvitePage() {
   const router = useRouter();
@@ -90,8 +91,9 @@ export default function InvitePage() {
   
   
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <div className="bg-white p-8 rounded-lg shadow-md max-w-xs w-full">        
+    <div className="relative flex items-center justify-center min-h-screen p-8 bg-gray-50 overflow-hidden">
+      <TickCrossBackground />
+      <div className="relative z-10 bg-white p-8 rounded-lg shadow-md max-w-xs w-full">
         {error ? (
           <div className="text-red-500 text-center mb-4">{error}</div>
         ) : (

--- a/src/components/auth/ProfileSetup.tsx
+++ b/src/components/auth/ProfileSetup.tsx
@@ -104,10 +104,10 @@ export default function ProfileSetup({ userId }: ProfileSetupProps) {
           
           <div className="space-y-2">
             <label className="block text-sm font-medium text-gray-700">
-              Choose Your Color Wisely...
+              Color
             </label>
             <p className="text-xs text-gray-500">
-              ... you will not be able to change it.
+              You can also change it per group.
             </p>
             <div className="relative">
               <button


### PR DESCRIPTION
## Summary
- Show tick and cross grid background while validating invites
- Display spinning red cross button during dashboard loading

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a752a9f48330b0a906f385976f96