### PR TITLE
fix: center tick-cross background

### DIFF
--- a/src/components/auth/TickCrossBackground.tsx
+++ b/src/components/auth/TickCrossBackground.tsx
@@ -41,8 +41,12 @@ export default function TickCrossBackground() {
 
   return (
     <div
-      className="absolute inset-0 grid"
+      className="fixed z-0 grid"
       style={{
+        left: `calc(50% - ${(cols * CELL_SIZE) / 2}px)`,
+        top: `calc(50% - ${(rows * CELL_SIZE) / 2}px)`,
+        width: `${cols * CELL_SIZE}px`,
+        height: `${rows * CELL_SIZE}px`,
         gridTemplateColumns: `repeat(${cols}, ${CELL_SIZE}px)`,
         gridTemplateRows: `repeat(${rows}, ${CELL_SIZE}px)`,
       }}


### PR DESCRIPTION
## Summary
- center TickCrossBackground grid within viewport for symmetrical appearance

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898af45cfa083309ba75c9288dd29fe