### PR TITLE
fix: refresh comment task references after changing groups

### DIFF
--- a/src/components/comments/CommentSection.tsx
+++ b/src/components/comments/CommentSection.tsx
@@ -75,12 +75,13 @@ export default function CommentSection({
 
   // Fetch tasks referenced by comments
   useEffect(() => {
+    let isCancelled = false;
+
     const fetchTasks = async () => {
-      const taskIds = Array.from(new Set(
-        comments
-          .filter(c => c.taskId)
-          .map(c => c.taskId as string)
-      ));
+      const taskIds = Array.from(
+        new Set(comments.filter(c => c.taskId).map(c => c.taskId as string))
+      );
+
       if (taskIds.length === 0) {
         setCommentTasks({});
         return;
@@ -134,10 +135,18 @@ export default function CommentSection({
           }
         })
       );
-      setCommentTasks(tasksMap);
+
+      if (!isCancelled) {
+        setCommentTasks(tasksMap);
+      }
     };
+
     fetchTasks();
-  }, [comments, groupId, members]);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [comments, groupId, currentWeekId, members]);
 
   // Add an effect to handle the Escape key press
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent stale task data in comments when switching groups by cancelling outdated fetches

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689adc2915608330bff3a7632f06df5a