### PR TITLE
feat: open comments on task double click

### DIFF
--- a/src/components/tracker/TaskCell.tsx
+++ b/src/components/tracker/TaskCell.tsx
@@ -20,6 +20,7 @@ interface TaskCellProps {
   onStopTimer?: (taskId: string) => void;
   isCurrentUser: boolean;
   onSelectTask?: (task: Task | null) => void;
+  onTaskDoubleClick?: (task: Task) => void;
   selectedTaskId?: string | null;
   highlightedTaskId?: string | null;
   onAcceptTask?: (taskId: string) => void;
@@ -47,6 +48,7 @@ export default function TaskCell({
   onStopTimer,
   isCurrentUser,
   onSelectTask,
+  onTaskDoubleClick,
   selectedTaskId,
   highlightedTaskId,
   onAcceptTask,
@@ -242,6 +244,7 @@ export default function TaskCell({
               isCurrentUser={isCurrentUser}
               isHighlighted={task.id === selectedTaskId || task.id === highlightedTaskId}
               onSelect={onSelectTask ? () => onSelectTask(task) : undefined}
+              onDoubleClick={onTaskDoubleClick ? () => onTaskDoubleClick(task) : undefined}
               onAcceptTask={task.suggestedBy && isCurrentUser && onAcceptTask ?
                 () => onAcceptTask(task.id) : undefined}
               onRejectTask={task.suggestedBy && isCurrentUser && onRejectTask ?

--- a/src/components/tracker/TaskItem.tsx
+++ b/src/components/tracker/TaskItem.tsx
@@ -8,6 +8,7 @@ interface TaskItemProps {
   isCurrentUser: boolean;
   isHighlighted?: boolean;
   onSelect?: () => void;
+  onDoubleClick?: () => void;
   onDelete?: () => void;
   onEdit?: (newText: string) => void;
   onAcceptTask?: () => void;
@@ -23,9 +24,10 @@ interface TaskItemProps {
 export default function TaskItem({ 
   task, 
   onUpdateStatus, 
-  isCurrentUser , 
+  isCurrentUser ,
   isHighlighted = false,
   onSelect,
+  onDoubleClick,
   onDelete,
   onEdit,
   onAcceptTask,
@@ -148,6 +150,7 @@ export default function TaskItem({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onClick={handleClick}
+      onDoubleClick={onDoubleClick}
       data-task-item="true"
     >
       {/* Comment icon - shows in top right corner when task has comments */}

--- a/src/components/tracker/TaskTracker.tsx
+++ b/src/components/tracker/TaskTracker.tsx
@@ -156,6 +156,13 @@ export default function TaskTracker({
     .filter(comment => comment.taskId !== null)
     .map(comment => comment.taskId as string);
 
+  const handleTaskDoubleClick = (task: Task) => {
+    onSelectTask?.(task);
+    if (isRightSidebarCollapsed && onToggleRightSidebar) {
+      onToggleRightSidebar();
+    }
+  };
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.innerWidth >= 640) return;
@@ -766,6 +773,7 @@ export default function TaskTracker({
                       onStopTimer={(taskId) => handleStopTaskTimer(member.id, taskId)}
                       isCurrentUser={member.id === user?.uid}
                       onSelectTask={onSelectTask ? (task) => onSelectTask(task) : undefined}
+                      onTaskDoubleClick={handleTaskDoubleClick}
                       selectedTaskId={selectedTask?.id}
                       highlightedTaskId={highlightedTaskId}
                       onAcceptTask={(taskId) => handleAcceptTask(member.id, taskId)}


### PR DESCRIPTION
## Summary
- open comments sidebar when a task is double-clicked
- wire TaskItem, TaskCell, and TaskTracker to handle task double clicks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3b81090083308b236c2dd214b959