### PR TITLE
Add plus subscription page

### DIFF
--- a/src/app/plus/page.tsx
+++ b/src/app/plus/page.tsx
@@ -1,20 +1,53 @@
 import TickCrossBackground from '../../components/auth/TickCrossBackground';
+import { PlusIcon, CheckIcon } from '@heroicons/react/24/outline';
 
 export default function PlusPage() {
   return (
     <div className="relative flex items-center justify-center min-h-screen p-4 bg-gray-50 overflow-hidden">
       <TickCrossBackground />
-      <div className="relative z-10 bg-white p-8 rounded-lg shadow-md max-w-md w-full text-center">
-        <h1 className="text-2xl font-bold mb-4">CheatCode Plus</h1>
-        <p className="text-xl text-gray-700 mb-6">$9.99 / month</p>
-        <ul className="text-left mb-6 list-disc list-inside space-y-2 text-gray-700">
-          <li>Unlimited tasks and check-ins</li>
-          <li>Priority support</li>
-          <li>Early access to new features</li>
-        </ul>
-        <button className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md">
+      <div className="relative z-10 bg-white p-10 rounded-xl shadow-xl border border-gray-100 max-w-lg w-full text-center">
+        <div className="flex w-full items-center justify-center gap-3 mb-6">
+          <h1 className="text-3xl text-gray-900 font-extrabold tracking-tight">cheat-code Plus</h1>
+          <div className="bg-green-50 p-2 rounded-full">
+            <PlusIcon className="h-8 w-8 text-green-600 stroke-2" />
+          </div>
+        </div>
+        <div className="mb-8">
+          <p className="text-2xl text-gray-900 font-semibold mb-1">only for $9.99 / month</p>
+          <p className="text-sm text-gray-500">Cancel anytime • 30-day money-back guarantee</p>
+        </div>
+        <div className="bg-gray-50 rounded-lg p-6 mb-8">
+          <ul className="text-left space-y-4 text-gray-700">
+            <li className="flex items-start gap-3">
+              <div className="bg-green-100 p-1 rounded-full mt-0.5">
+                <CheckIcon className="h-4 w-4 text-green-600 stroke-2" />
+              </div>
+              <span className="font-medium">Unlimited tasks and groups</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <div className="bg-green-100 p-1 rounded-full mt-0.5">
+                <CheckIcon className="h-4 w-4 text-green-600 stroke-2" />
+              </div>
+              <span className="font-medium">Priority support</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <div className="bg-green-100 p-1 rounded-full mt-0.5">
+                <CheckIcon className="h-4 w-4 text-green-600 stroke-2" />
+              </div>
+              <span className="font-medium">Early access to new features</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <div className="bg-green-100 p-1 rounded-full mt-0.5">
+                <CheckIcon className="h-4 w-4 text-green-600 stroke-2" />
+              </div>
+              <span className="font-medium">Support the developers!</span>
+            </li>
+          </ul>
+        </div>
+        <button className="w-full bg-theme hover:bg-theme-hover text-white font-semibold px-8 py-3 rounded-lg transition-colors duration-200 shadow-sm hover:shadow-md">
           Subscribe Now
         </button>
+        <p className="text-xs text-gray-400 mt-4">Secure payment • SSL encrypted</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Plus subscription landing page with perks and Subscribe Now button
- apply TickCross background to Plus page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3c7c68288330aa29b6418a45ccb4