### PR TITLE
Linkify URLs in tasks and comments

### DIFF
--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Comment, Task } from '../../types';
 import { TrashIcon } from '@heroicons/react/24/outline';
+import { linkifyText } from '../../lib/linkify';
 
 interface CommentItemProps {
   comment: Comment;
@@ -75,7 +76,9 @@ export default function CommentItem({ comment, onHover, onLeave, isHighlighted, 
           <div className="text-xs text-gray-500">{formatDateTime(comment.createdAt)}</div>
         </div>
       </div>
-      <div className="text-sm text-gray-900 whitespace-pre-wrap break-words">{comment.text}</div>
+      <div className="text-sm text-gray-900 whitespace-pre-wrap break-words">
+        {linkifyText(comment.text)}
+      </div>
       {task && taskOwner && (
         <div className="mt-2 flex items-center">
           <div
@@ -84,7 +87,9 @@ export default function CommentItem({ comment, onHover, onLeave, isHighlighted, 
           >
             {taskOwner.name.charAt(0)}
           </div>
-          <div className="text-xs text-gray-600 truncate flex-1">{task.text}</div>
+          <div className="text-xs text-gray-600 truncate flex-1">
+            {linkifyText(task.text)}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/tracker/TaskItem.tsx
+++ b/src/components/tracker/TaskItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Task } from '../../types';
 import { ArrowRightIcon, TrashIcon, PlayIcon, PauseIcon, XMarkIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { linkifyText } from '../../lib/linkify';
 
 interface TaskItemProps {
   task: Task;
@@ -297,14 +298,14 @@ export default function TaskItem({
         </div>
       ) : (
         <span
-          className={`ml-5 pl-1 block break-words overflow-hidden text-ellipsis ${ 
-            !isEditing && 
+          className={`ml-5 pl-1 block break-words overflow-hidden text-ellipsis ${
+            !isEditing &&
             (task.timerStartedAt || elapsed > 0)
               ? 'max-w-7/10'
               : ''
           }`}
         >
-            {task.text}
+            {linkifyText(task.text)}
         </span>
       )}
     </div>

--- a/src/lib/linkify.tsx
+++ b/src/lib/linkify.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+/**
+ * Convert URLs in text to clickable links.
+ * Only matches http and https schemes to avoid javascript injections.
+ */
+export function linkifyText(text: string): React.ReactNode {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  return text.split(urlRegex).map((part, index) => {
+    if (part.match(urlRegex)) {
+      return (
+        <a
+          key={index}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 underline"
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+}


### PR DESCRIPTION
## Summary
- render URLs in tasks and comments as clickable links
- introduce shared `linkifyText` helper for safe URL detection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c378b6ee88330baeab409ccf2871d