### PR TITLE
Add welcome task for new users

### DIFF
--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -1,14 +1,15 @@
 import { useState, useEffect } from 'react';
-import { 
-  signInWithPopup, 
+import {
+  signInWithPopup,
   GoogleAuthProvider,
-  onAuthStateChanged, 
+  onAuthStateChanged,
   signOut,
-  User 
+  User
 } from 'firebase/auth';
-import { doc, setDoc, getDoc, updateDoc, arrayUnion } from 'firebase/firestore';
+import { collection, addDoc, doc, setDoc, getDoc, updateDoc, arrayUnion } from 'firebase/firestore';
 import { nanoid } from 'nanoid';
 import { auth, db } from '../firebase';
+import { getCurrentISOWeek } from '../dateUtils';
 
 let createUserPromise: Promise<void> | null = null;
 
@@ -63,6 +64,19 @@ export function useAuth() {
 
                   await updateDoc(userRef, {
                     groups: arrayUnion(groupId)
+                  });
+
+                  const today = new Date();
+                  const day = (today.getDay() + 6) % 7;
+                  await addDoc(collection(db, 'groups', groupId, 'tasks'), {
+                    text: 'Invite a friend',
+                    status: 'not-done',
+                    day,
+                    createdBy: authUser.uid,
+                    createdAt: today,
+                    weekId: getCurrentISOWeek(),
+                    timerStartedAt: null,
+                    elapsedSeconds: 0
                   });
                 }
               } finally {


### PR DESCRIPTION
## Summary
- create a default group task for new users to invite a friend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62127e5f08330a15fd46e76e1579c